### PR TITLE
Log failures in HubSpot data ingestion

### DIFF
--- a/src/HubSpot.Crawling/Crawler.cs
+++ b/src/HubSpot.Crawling/Crawler.cs
@@ -64,37 +64,36 @@ namespace CluedIn.Crawling.HubSpot
                 _log.Error("HubSpot daily usage limit has been reached");
                 return EmptyResult;
             }
-            
 
             var data = new List<object>();
 
-            data.AddRange(new CompanyIterator(client, crawlerJobData, settings).Iterate());
-            data.AddRange(new DealIterator(client, crawlerJobData, settings).Iterate());
-            data.AddRange(new ContactIterator(client, crawlerJobData, settings).Iterate());
-            data.AddRange(new DynamicContactListIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new FormsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new OwnersIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new PublishingChannelsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new FilesIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new SiteMapsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new TemplatesIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new UrlMappingsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new EngagementsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new RecentDealsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new RecentlyCreatedDealsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new SmtpTokensIterator(client, crawlerJobData).Iterate());            
-            data.AddRange(new SocialCalendarEventsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new StaticContactListIterator(client,crawlerJobData).Iterate());
-            data.AddRange(new TaskCalendarEventsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new WorkflowsIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new BlogPostsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new BlogsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new BlogTopicsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new DomainsIterator(client, crawlerJobData).Iterate()); 
-            data.AddRange(new BroadcastMessagesIterator(client, crawlerJobData).Iterate());
-            data.AddRange(new ProductsIterator(client, crawlerJobData, settings).Iterate());
-            data.AddRange(new LineItemsIterator(client, crawlerJobData, settings).Iterate());
-            data.AddRange(new TicketsIterator(client, crawlerJobData, settings).Iterate());
+            data.AddRange(new CompanyIterator(client, crawlerJobData, settings, _log).Iterate());
+            data.AddRange(new DealIterator(client, crawlerJobData, settings, _log).Iterate());
+            data.AddRange(new ContactIterator(client, crawlerJobData, settings, _log).Iterate());
+            data.AddRange(new DynamicContactListIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new FormsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new OwnersIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new PublishingChannelsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new FilesIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new SiteMapsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new TemplatesIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new UrlMappingsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new EngagementsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new RecentDealsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new RecentlyCreatedDealsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new SmtpTokensIterator(client, crawlerJobData, _log).Iterate());            
+            data.AddRange(new SocialCalendarEventsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new StaticContactListIterator(client,crawlerJobData, _log).Iterate());
+            data.AddRange(new TaskCalendarEventsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new WorkflowsIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new BlogPostsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new BlogsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new BlogTopicsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new DomainsIterator(client, crawlerJobData, _log).Iterate()); 
+            data.AddRange(new BroadcastMessagesIterator(client, crawlerJobData, _log).Iterate());
+            data.AddRange(new ProductsIterator(client, crawlerJobData, settings, _log).Iterate());
+            data.AddRange(new LineItemsIterator(client, crawlerJobData, settings, _log).Iterate());
+            data.AddRange(new TicketsIterator(client, crawlerJobData, settings, _log).Iterate());
 
             return data;
         }

--- a/src/HubSpot.Crawling/Crawler.cs
+++ b/src/HubSpot.Crawling/Crawler.cs
@@ -31,7 +31,7 @@ namespace CluedIn.Crawling.HubSpot
             }
             catch (AggregateException e)
             {
-                _log.Error(e.InnerExceptions.First().Message);
+                _log.Error(() => e.InnerExceptions.First().Message, e);
                 throw e.InnerExceptions.First();
             }
         }
@@ -54,14 +54,14 @@ namespace CluedIn.Crawling.HubSpot
 
             if (settings == null)
             {
-                _log.Error("Settings could not be obtained from HubSpot");
+                _log.Error(() => "Settings could not be obtained from HubSpot");
                 return EmptyResult;
             }
 
             var dailyLimit = await client.GetDailyLimitAsync();
             if (dailyLimit.currentUsage >= dailyLimit.usageLimit)
             {
-                _log.Error("HubSpot daily usage limit has been reached");
+                _log.Error(() =>"HubSpot daily usage limit has been reached");
                 return EmptyResult;
             }
 

--- a/src/HubSpot.Crawling/Installers/InstallComponents.cs
+++ b/src/HubSpot.Crawling/Installers/InstallComponents.cs
@@ -1,19 +1,36 @@
 using System;
+
 using Castle.MicroKernel.Registration;
 using Castle.MicroKernel.SubSystems.Configuration;
 using Castle.Windsor;
-using CluedIn.Core;
+using CluedIn.Core.Logging;
+using CluedIn.Crawling.HubSpot.Iterators;
 
 namespace CluedIn.Crawling.HubSpot.Installers
 {
-    // Use this class to add any further dependencies to the container
-
     public class InstallComponents : IWindsorInstaller
     {
-        public void Install([NotNull] IWindsorContainer container, [NotNull] IConfigurationStore store)
+        public void Install(IWindsorContainer container, IConfigurationStore store)
         {
             if (container == null) throw new ArgumentNullException(nameof(container));
             if (store == null) throw new ArgumentNullException(nameof(store));
+
+            container
+                .Install(
+                    new Infrastructure.Installers.InstallComponents()
+                )
+
+                .Register(
+                    Component.For<ILogger>()
+                        .UsingFactoryMethod(() => GlobalLog.Console)
+                        .OnlyNewServices())
+
+                .Register(
+                    Component.For<IHubSpotIterator>()
+                        .ImplementedBy<AssociationsIterator>()
+                        .OnlyNewServices())
+
+                ;
         }
     }
 }

--- a/src/HubSpot.Crawling/Iterators/AssociationsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/AssociationsIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
+
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using CluedIn.Crawling.HubSpot.Infrastructure;
@@ -13,7 +14,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
         private readonly int _objectId;
         private readonly AssociationType _associationType;
 
-        public AssociationsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, int objectId, AssociationType associationType) : base(client, jobData)
+        public AssociationsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, int objectId, AssociationType associationType, ILogger logger)
+            : base(client, jobData, logger)
         {
             _objectId = objectId;
             _associationType = associationType;
@@ -60,7 +62,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/BlogPostsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/BlogPostsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class BlogPostsIterator : HubSpotIteratorBase
     {
-        public BlogPostsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public BlogPostsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -50,7 +52,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/BlogTopicsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/BlogTopicsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class BlogTopicsIterator : HubSpotIteratorBase
     {
-        public BlogTopicsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public BlogTopicsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/BlogsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/BlogsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class BlogsIterator : HubSpotIteratorBase
     {
-        public BlogsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public BlogsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/BroadcastMessagesIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/BroadcastMessagesIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class BroadcastMessagesIterator : HubSpotIteratorBase
     {
-        public BroadcastMessagesIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public BroadcastMessagesIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/ContactIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/ContactIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using CluedIn.Crawling.HubSpot.Infrastructure;
@@ -12,7 +13,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
     {
         private readonly Settings _settings;
 
-        public ContactIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Settings settings) : base(client, jobData)
+        public ContactIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Settings settings, ILogger logger)
+            : base(client, jobData, logger)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
@@ -45,9 +47,9 @@ namespace CluedIn.Crawling.HubSpot.Iterators
                                 {
                                     result.AddRange(Client.GetEngagementByIdAndTypeAsync(contact.Vid.Value, "CONTACT").Result);
                                 }
-                                catch
+                                catch (Exception exception)
                                 {
-                                    // ignored
+                                    Logger.Warn(() => $"Failed to get Engagements for Contact {contact.Vid.Value}", exception);
                                 }
                             }
 
@@ -73,7 +75,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/DealIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/DealIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using CluedIn.Crawling.HubSpot.Infrastructure;
@@ -12,7 +13,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
     {
         private readonly Settings _settings;
 
-        public DealIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Settings settings) : base(client, jobData)
+        public DealIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Settings settings, ILogger logger)
+            : base(client, jobData, logger)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
@@ -51,9 +53,9 @@ namespace CluedIn.Crawling.HubSpot.Iterators
                                     var engagements = Client.GetEngagementByIdAndTypeAsync(deal.dealId.Value, "DEAL").Result;
                                     result.AddRange(engagements);
                                 }
-                                catch
+                                catch (Exception exception)
                                 {
-                                    // ignored
+                                    Logger.Warn(() => $"Failed to get Engagements for Deal {deal.dealId.Value}", exception);
                                 }
                             }
 
@@ -79,7 +81,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/DomainsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/DomainsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class DomainsIterator : HubSpotIteratorBase
     {
-        public DomainsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public DomainsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/DynamicContactListIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/DynamicContactListIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class DynamicContactListIterator : HubSpotIteratorBase
     {
-        public DynamicContactListIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public DynamicContactListIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,8 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/EngagementsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/EngagementsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class EngagementsIterator : HubSpotIteratorBase
     {
-        public EngagementsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public EngagementsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/FilesIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/FilesIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class FilesIterator : HubSpotIteratorBase
     {
-        public FilesIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public FilesIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/FormsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/FormsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 
@@ -7,7 +8,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class FormsIterator : HubSpotIteratorBase
     {
-        public FormsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public FormsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -19,7 +21,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
         }
     }

--- a/src/HubSpot.Crawling/Iterators/HubSpotIteratorBase.cs
+++ b/src/HubSpot.Crawling/Iterators/HubSpotIteratorBase.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -9,8 +12,11 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public abstract class HubSpotIteratorBase : IHubSpotIterator
     {
-        protected HubSpotIteratorBase(IHubSpotClient client, HubSpotCrawlJobData jobData)
+        protected readonly ILogger Logger;
+
+        protected HubSpotIteratorBase(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
         {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Client = client ?? throw new ArgumentNullException(nameof(client));
             JobData = jobData ?? throw new ArgumentNullException(nameof(jobData));
         }
@@ -18,6 +24,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
         public abstract IEnumerable<object> Iterate(int? limit = null);
 
         public IHubSpotClient Client { get; }
+
         public HubSpotCrawlJobData JobData { get; }
 
         public int MaxRetries { get; set; } = 3;
@@ -27,22 +34,34 @@ namespace CluedIn.Crawling.HubSpot.Iterators
         {
             if (e.DailyRemaining <= 0)
             {
+                Logger.Warn(() => "Exceeded daily quota");
                 return false;
             }
 
             if (e.RateLimitRemaining > 0)
             {
+                Logger.Verbose(() => $"Retrying request, {e.RateLimitRemaining} remaining attempts");
+
                 return true;
             }
 
             if (retries < MaxRetries)
             {
+                Logger.Verbose(() => $"Retrying request in {e.RateLimitIntervalMilliseconds} milliseconds");
+
                 Thread.Sleep(e.RateLimitIntervalMilliseconds);
                 return true;
             }
 
-            return false;
+            Logger.Warn(() => $"Failed request after {MaxRetries} retries");
 
+            return false;
+        }
+
+        protected IEnumerable<object> CreateEmptyResults()
+        {
+            Logger.Warn(() => $"Failed to retrieve data in {GetType().FullName}");
+            return Enumerable.Empty<object>();
         }
     }
 }

--- a/src/HubSpot.Crawling/Iterators/OwnersIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/OwnersIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 
@@ -7,7 +8,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class OwnersIterator : HubSpotIteratorBase
     {
-        public OwnersIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public OwnersIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -19,7 +21,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
         }
     }

--- a/src/HubSpot.Crawling/Iterators/ProductsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/ProductsIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using CluedIn.Crawling.HubSpot.Infrastructure;
@@ -12,7 +13,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
     {
         private readonly Settings _settings;
 
-        public ProductsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Settings settings) : base(client, jobData)
+        public ProductsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Settings settings, ILogger logger)
+            : base(client, jobData, logger)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
@@ -59,7 +61,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/PublishingChannelsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/PublishingChannelsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 
@@ -7,7 +8,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class PublishingChannelsIterator : HubSpotIteratorBase
     {
-        public PublishingChannelsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public PublishingChannelsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -19,7 +21,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
         }
     }

--- a/src/HubSpot.Crawling/Iterators/RecentDealsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/RecentDealsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class RecentDealsIterator : HubSpotIteratorBase
     {
-        public RecentDealsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public RecentDealsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/RecentlyCreatedDealsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/RecentlyCreatedDealsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class RecentlyCreatedDealsIterator : HubSpotIteratorBase
     {
-        public RecentlyCreatedDealsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public RecentlyCreatedDealsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/SiteMapsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/SiteMapsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class SiteMapsIterator : HubSpotIteratorBase
     {
-        public SiteMapsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public SiteMapsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/SmtpTokensIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/SmtpTokensIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 
@@ -7,7 +8,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class SmtpTokensIterator : HubSpotIteratorBase
     {
-        public SmtpTokensIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public SmtpTokensIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -19,7 +21,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
         }
     }

--- a/src/HubSpot.Crawling/Iterators/SocialCalendarEventsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/SocialCalendarEventsIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -9,7 +10,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class SocialCalendarEventsIterator : HubSpotIteratorBase
     {
-        public SocialCalendarEventsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public SocialCalendarEventsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -52,7 +54,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/StaticContactListIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/StaticContactListIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class StaticContactListIterator : HubSpotIteratorBase
     {
-        public StaticContactListIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public StaticContactListIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/TableRowsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/TableRowsIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using CluedIn.Crawling.HubSpot.Infrastructure;
@@ -13,7 +14,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
         private readonly Table _table;
         private readonly long _portalId;
 
-        public TableRowsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Table table, long portalId) : base(client, jobData)
+        public TableRowsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, Table table, long portalId, ILogger logger)
+            : base(client, jobData, logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
             _portalId = portalId;
@@ -67,7 +69,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/TaskCalendarEventsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/TaskCalendarEventsIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -9,7 +10,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class TaskCalendarEventsIterator : HubSpotIteratorBase
     {
-        public TaskCalendarEventsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public TaskCalendarEventsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -52,7 +54,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/TemplatesIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/TemplatesIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class TemplatesIterator : HubSpotIteratorBase
     {
-        public TemplatesIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public TemplatesIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -52,7 +54,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/UrlMappingsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/UrlMappingsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
@@ -8,7 +9,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class UrlMappingsIterator : HubSpotIteratorBase
     {
-        public UrlMappingsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public UrlMappingsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -51,7 +53,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
 
             return result;

--- a/src/HubSpot.Crawling/Iterators/WorkflowsIterator.cs
+++ b/src/HubSpot.Crawling/Iterators/WorkflowsIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Infrastructure;
 
@@ -7,7 +8,8 @@ namespace CluedIn.Crawling.HubSpot.Iterators
 {
     public class WorkflowsIterator : HubSpotIteratorBase
     {
-        public WorkflowsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData) : base(client, jobData)
+        public WorkflowsIterator(IHubSpotClient client, HubSpotCrawlJobData jobData, ILogger logger)
+            : base(client, jobData, logger)
         {
         }
 
@@ -19,7 +21,7 @@ namespace CluedIn.Crawling.HubSpot.Iterators
             }
             catch
             {
-                return Enumerable.Empty<object>();
+                return CreateEmptyResults();
             }
         }
     }

--- a/src/HubSpot.Infrastructure/HubspotClient.cs
+++ b/src/HubSpot.Infrastructure/HubspotClient.cs
@@ -514,7 +514,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
 
         private T GetRequestResponse<T>(string url, IRestResponse response)
         {
-            _log.Verbose($"HubSpotClient.GetAsync calling {url}");
+            _log.Verbose(() =>$"HubSpotClient.GetAsync calling {url}");
             if ((int)response.StatusCode == 429)
             {
                 throw new ThrottlingException
@@ -536,7 +536,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
 
             var data = JsonConvert.DeserializeObject<T>(response.Content);
 
-            _log.Verbose($"HubSpotClient returning {data}");
+            _log.Verbose(() =>$"HubSpotClient returning {data}");
 
             return data;
         }

--- a/src/HubSpot.Infrastructure/HubspotClient.cs
+++ b/src/HubSpot.Infrastructure/HubspotClient.cs
@@ -536,7 +536,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
 
             var data = JsonConvert.DeserializeObject<T>(response.Content);
 
-            _log.Verbose(() =>$"HubSpotClient returning {data}");
+            _log.Verbose(() =>$"HubSpotClient response content length: {response.Content.Length}");
 
             return data;
         }

--- a/src/HubSpot.Infrastructure/Installers/InstallComponents.cs
+++ b/src/HubSpot.Infrastructure/Installers/InstallComponents.cs
@@ -16,10 +16,20 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure.Installers
         {
             container
                 .AddFacilityIfNotExists<TypedFactoryFacility>()
-                .Register(Component.For<IHubSpotClientFactory>().AsFactory())
-                .Register(Component.For<IHubSpotFileFetcher, HubSpotFileFetcher>())
-                .Register(Component.For<IHubSpotFileIndexer, HubSpotFileIndexer>())
-                .Register(Component.For<IHubSpotClient, HubSpotClient>().LifestyleTransient());
+                .Register(
+                    Component.For<IHubSpotClientFactory>()
+                        .AsFactory()
+                        .OnlyNewServices())
+                .Register(
+                    Component.For<IHubSpotFileFetcher, HubSpotFileFetcher>()
+                        .OnlyNewServices())
+                .Register(
+                    Component.For<IHubSpotFileIndexer, HubSpotFileIndexer>()
+                        .OnlyNewServices())
+                .Register(
+                    Component.For<IHubSpotClient, HubSpotClient>()
+                        .LifestyleTransient()
+                        .OnlyNewServices());
 
             if (!container.Kernel.HasComponent(typeof(ISystemNotifications)) && !container.Kernel.HasComponent(typeof(SystemNotifications)))
             {

--- a/test/integration/Crawling.HubSpot.Integration.Test/HubSpotClient/HappyPath.cs
+++ b/test/integration/Crawling.HubSpot.Integration.Test/HubSpotClient/HappyPath.cs
@@ -12,6 +12,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Crawling.HubSpot.Integration.Test.HubSpotClient
 {
+    [Trait("Category", "web")]
     public class HappyPath
     {
         private readonly CluedIn.Crawling.HubSpot.Infrastructure.HubSpotClient _sut;

--- a/test/integration/Crawling.HubSpot.Integration.Test/HubspotDataIngestion.cs
+++ b/test/integration/Crawling.HubSpot.Integration.Test/HubspotDataIngestion.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace Crawling.HubSpot.Integration.Test
 {
+    [Trait("Category", "web")]
     public class DataIngestion : IClassFixture<HubSpotTestFixture>
     {
         private readonly HubSpotTestFixture _fixture;

--- a/test/integration/Crawling.HubSpot.Integration.Test/HubspotTestFixture.cs
+++ b/test/integration/Crawling.HubSpot.Integration.Test/HubspotTestFixture.cs
@@ -1,11 +1,11 @@
 using System.IO;
 using System.Reflection;
-using Castle.Windsor;
-using CluedIn.Core;
+
 using CluedIn.Core.Installers;
-using CluedIn.Crawling;
 using CluedIn.Crawling.HubSpot.Core;
+
 using CrawlerIntegrationTesting.Clues;
+
 using Crawling.HubSpot.Test.Common;
 
 namespace Crawling.HubSpot.Integration.Test

--- a/test/unit/Crawling.HubSpot.Unit.Test/IteratorTests/BlogIteratorTest.cs
+++ b/test/unit/Crawling.HubSpot.Unit.Test/IteratorTests/BlogIteratorTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CluedIn.Core.Logging;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using CluedIn.Crawling.HubSpot.Infrastructure.Exceptions;
 using CluedIn.Crawling.HubSpot.Iterators;
@@ -13,11 +14,13 @@ namespace Crawling.HubSpot.Unit.Test.IteratorTests
 {
     public class BlogIteratorTest : BaseIteratorTest
     {
-        private BlogsIterator _sut;
-        
+        private readonly BlogsIterator _sut;
+        private readonly Mock<ILogger> _loggerMock;
+
         public BlogIteratorTest()
         {
-            _sut = new BlogsIterator(Client.Object, JobData);
+            _loggerMock = new Mock<ILogger>();
+            _sut = new BlogsIterator(Client.Object, JobData, _loggerMock.Object);
         }
 
         [Fact]


### PR DESCRIPTION
Summary of changes:

* Use `Func<string>` overloads of `CluedIn.Core.Logging.ILogger` methods to avoid throwing`MissingMethodException` at runtime

* Add logging of warning and error level events when crawling HubSpot