### PR TITLE
DI issue with ILogger on FileMetaDataClueProducer ctor

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
+    <_CacheCow>2.7.2</_CacheCow>
+    <_EasyNetQ>3.7.1</_EasyNetQ>
+    <_EntityFramework>3.1.3</_EntityFramework>
+    <_MicrosoftExtensions>3.1.3</_MicrosoftExtensions>
     <_ComponentHost>2.0.0-alpha-14</_ComponentHost>
     <_AutoFixture>4.11.0</_AutoFixture>
     <_CluedIn>3.0.0-netcore.*</_CluedIn>
@@ -30,11 +34,13 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
+    <PackageReference Update="Castle.Windsor" Version="5.0.1" />
     <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
-    <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
+    <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="$(_CluedIn)" />
+    <PackageReference Update="RestSharp" Version="106.10.1" />
 
   </ItemGroup>
 

--- a/src/HubSpot.Crawling/ClueProducers/FileMetaDataClueProducer.cs
+++ b/src/HubSpot.Crawling/ClueProducers/FileMetaDataClueProducer.cs
@@ -16,18 +16,12 @@ namespace CluedIn.Crawling.HubSpot.ClueProducers
     public class FileMetaDataClueProducer : BaseClueProducer<FileMetaData>
     {
         private readonly IClueFactory _factory;
-        private readonly ILogger _log;
         private readonly IHubSpotFileFetcher _fileFetcher;
-        private readonly ApplicationContext _context;
-        private readonly IAgentJobProcessorState<CrawlJobData> _state;
 
-        public FileMetaDataClueProducer(IClueFactory factory, IHubSpotFileFetcher fileFetcher, ILogger log, ApplicationContext context, IAgentJobProcessorState<CrawlJobData> state)
+        public FileMetaDataClueProducer(IClueFactory factory, IHubSpotFileFetcher fileFetcher)
         {
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
             _fileFetcher = fileFetcher ?? throw new ArgumentNullException(nameof(_fileFetcher));
-            _log = log ?? throw new ArgumentNullException(nameof(log));
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _state = state ?? throw new ArgumentNullException(nameof(state));
         }
 
         protected override Clue MakeClueImpl(FileMetaData input, Guid accountId)

--- a/src/HubSpot.Infrastructure/Installers/InstallComponents.cs
+++ b/src/HubSpot.Infrastructure/Installers/InstallComponents.cs
@@ -38,7 +38,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure.Installers
 
             if (!container.Kernel.HasComponent(typeof(IRestClient)) && !container.Kernel.HasComponent(typeof(RestClient)))
             {
-                container.Register(Component.For<IRestClient, RestClient>());
+                container.Register(Component.For<IRestClient, RestClient>().LifestyleTransient());
             }
         }
     }


### PR DESCRIPTION
Fixes #50 

DI setup wrong for `FileMetaDataClueProducer` ctor

Fixes following error:
```
Missing dependency.
Component CluedIn.Crawling.HubSpot.ClueProducers.FileMetaDataClueProducer has a dependency on Microsoft.Extensions.Logging.ILogger, which could not be resolved.
Make sure the dependency is correctly registered in the container as a service, or provided as inline argument.
```