### PR TITLE
feature: Add extension to filter vocab [AB#13019]

### DIFF
--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -37,7 +37,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
         public void TryAdd(HubspotProperty hubspotProperty)
         {
-            if (properties.Any(p => p.name == hubspotProperty.name))
+            if (properties.Any(p => p.property == hubspotProperty.property))
             {
                 return;
             }
@@ -48,13 +48,14 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
     public class HubspotProperty
     {
-        public HubspotProperty(string name, string value, string prefix)
+        public HubspotProperty(string property, string value, string prefix)
         {
-            this.name = name.ToLower().Replace(prefix, "");
+            this.property = property.ToLower().Replace(prefix, "")
+                .Replace("companyname", "company");
             this.value = value;
         }
 
-        public string name { get; set; }
+        public string property { get; set; }
         public string value { get; set; }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CluedIn.Core.Mesh;
+
+namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
+{
+    public static class PropertiesExtensions
+    {
+        public static HubspotProperties ToHubspotProperties(this Properties properties)
+        {
+            var hubspotProperties = new HubspotProperties();
+            foreach (var property in properties.properties.Where(property => property.name.Contains("hubspot.contact", StringComparison.OrdinalIgnoreCase)))
+            {
+                hubspotProperties.TryAdd(
+                    new HubspotProperty(property.name, property.value));
+            }
+
+            return hubspotProperties;
+        }
+    }
+
+    public class HubspotProperties
+    {
+        public List<HubspotProperty> properties { get; set; }
+
+        public HubspotProperties()
+        {
+            properties = new List<HubspotProperty>();
+        }
+
+        public void TryAdd(HubspotProperty hubspotProperty)
+        {
+            if (properties.Any(p => p.property == hubspotProperty.property))
+            {
+                return;
+            }
+
+            properties.Add(hubspotProperty);
+        }
+    }
+
+    public class HubspotProperty
+    {
+        public HubspotProperty(string property, string value)
+        {
+            this.property = property.ToLower().Replace("hubspot.contact.", "");
+            this.value = value;
+        }
+
+        public string property { get; set; }
+        public string value { get; set; }
+    }
+}

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -38,7 +38,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
         public void AddIfNotExists(HubSpotProperty hubspotProperty)
         {
-            if (properties.Any(p => p.Property == hubspotProperty.Property))
+            if (properties.Any(p => p.property == hubspotProperty.property))
             {
                 return;
             }
@@ -55,13 +55,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
         public HubSpotProperty(string name, string value, string prefix)
         {
-            Name = name;
-            Value = value;
-            Prefix = prefix;
+            this.Name = name;
+            this.value = value;
+            this.Prefix = prefix;
         }
-
-        [JsonPropertyName("property")]
-        public string Property
+        
+        public string property
         {
             get
             {
@@ -72,8 +71,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
                     .Replace("companyname", "company");
             }
         }
-
-        [JsonPropertyName("value")]
-        public string Value { get; }
+        
+        public string value { get; }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -52,32 +52,27 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class HubSpotProperty
     {
-        private readonly string _name;
-        private readonly string _prefix;
-
         public HubSpotProperty(string name, string value, string prefix)
         {
-            _name = string.IsNullOrEmpty(name) ? string.Empty : name.ToLower();
-            _prefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix.ToLower();
-
+            this.Property = ResolveProperty(name, prefix);
             this.Value = value;
         }
 
-        public string Property
-        {
-            get
-            {
-                var returnValue = _name;
-
-                if (returnValue.StartsWith(_prefix, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    returnValue = returnValue.Remove(0, _prefix.Length);
-                }
-
-                return returnValue.Replace("companyname", "company");
-            }
-        }
+        public string Property { get; }
 
         public string Value { get; }
+
+        private static string ResolveProperty(string name, string prefix)
+        {
+            var returnValue = string.IsNullOrEmpty(name) ? string.Empty : name.ToLower();
+            var normalizedPrefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix.ToLower();
+
+            if (returnValue.StartsWith(normalizedPrefix, StringComparison.InvariantCultureIgnoreCase))
+            {
+                returnValue = returnValue.Remove(0, normalizedPrefix.Length);
+            }
+
+            return returnValue.Replace("companyname", "company");
+        }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
 using Castle.Core.Internal;
 using CluedIn.Core.Mesh;
 
@@ -12,12 +11,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
         public static HubSpotProperties ToHubSpotProperties(this Properties properties, string prefix)
         {
             var hubspotProperties = new HubSpotProperties();
-            if(properties?.properties == null || prefix.IsNullOrEmpty())
+            if (properties?.properties == null || prefix.IsNullOrEmpty())
             {
                 return null;
             }
 
-            foreach (var property in properties.properties.Where(property => property.name.Contains(prefix, StringComparison.OrdinalIgnoreCase)))
+            foreach (var property in properties.properties.Where(property => property.name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
             {
                 hubspotProperties.AddIfNotExists(
                     new HubSpotProperty(property.name, property.value, prefix));
@@ -49,29 +48,21 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
     public class HubSpotProperty
     {
-        
-        private string? Name { get; set; }
-        private string? Prefix { get; set; }
+        private readonly string _name;
+        private readonly string _prefix;
 
         public HubSpotProperty(string name, string value, string prefix)
         {
-            this.Name = name;
-            this.value = value;
-            this.Prefix = prefix;
-        }
-        
-        public string property
-        {
-            get
-            {
-                if(string.IsNullOrEmpty(Prefix)) Prefix = string.Empty;
+            _name = string.IsNullOrEmpty(name) ? string.Empty : name.ToLower();
+            _prefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix.ToLower();
 
-                return string.IsNullOrEmpty(Name) ? string.Empty : Name.Replace(Prefix, string.Empty)
-                    .ToLower()
-                    .Replace("companyname", "company");
-            }
+            this.value = value;
         }
-        
+
+        public string property =>
+            _name.Replace(_prefix, string.Empty)
+                .Replace("companyname", "company");
+
         public string value { get; }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -7,13 +7,13 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 {
     public static class PropertiesExtensions
     {
-        public static HubspotProperties ToHubspotProperties(this Properties properties)
+        public static HubspotProperties ToHubspotProperties(this Properties properties, string prefix)
         {
             var hubspotProperties = new HubspotProperties();
-            foreach (var property in properties.properties.Where(property => property.name.Contains("hubspot.contact", StringComparison.OrdinalIgnoreCase)))
+            foreach (var property in properties.properties.Where(property => property.name.Contains(prefix, StringComparison.OrdinalIgnoreCase)))
             {
                 hubspotProperties.TryAdd(
-                    new HubspotProperty(property.name, property.value));
+                    new HubspotProperty(property.name, property.value, prefix));
             }
 
             return hubspotProperties;
@@ -42,9 +42,9 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
     public class HubspotProperty
     {
-        public HubspotProperty(string property, string value)
+        public HubspotProperty(string property, string value, string prefix)
         {
-            this.property = property.ToLower().Replace("hubspot.contact.", "");
+            this.property = property.ToLower().Replace(prefix, "");
             this.value = value;
         }
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -63,9 +63,20 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
             this.Value = value;
         }
 
-        public string Property =>
-            _name.Replace(_prefix, string.Empty)
-                .Replace("companyname", "company");
+        public string Property
+        {
+            get
+            {
+                var returnValue = _name;
+
+                if (returnValue.StartsWith(_prefix, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    returnValue = returnValue.Remove(0, _prefix.Length);
+                }
+
+                return returnValue.Replace("companyname", "company");
+            }
+        }
 
         public string Value { get; }
     }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Castle.Core.Internal;
 using CluedIn.Core.Mesh;
 
 namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
@@ -10,6 +11,11 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
         public static HubspotProperties ToHubspotProperties(this Properties properties, string prefix)
         {
             var hubspotProperties = new HubspotProperties();
+            if(properties?.properties == null || prefix.IsNullOrEmpty())
+            {
+                return hubspotProperties;
+            }
+
             foreach (var property in properties.properties.Where(property => property.name.Contains(prefix, StringComparison.OrdinalIgnoreCase)))
             {
                 hubspotProperties.TryAdd(
@@ -31,7 +37,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
         public void TryAdd(HubspotProperty hubspotProperty)
         {
-            if (properties.Any(p => p.property == hubspotProperty.property))
+            if (properties.Any(p => p.name == hubspotProperty.name))
             {
                 return;
             }
@@ -42,13 +48,13 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 
     public class HubspotProperty
     {
-        public HubspotProperty(string property, string value, string prefix)
+        public HubspotProperty(string name, string value, string prefix)
         {
-            this.property = property.ToLower().Replace(prefix, "");
+            this.name = name.ToLower().Replace(prefix, "");
             this.value = value;
         }
 
-        public string property { get; set; }
+        public string name { get; set; }
         public string value { get; set; }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Castle.Core.Internal;
 using CluedIn.Core.Mesh;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
 {
@@ -26,26 +28,28 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
         }
     }
 
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class HubSpotProperties
     {
-        public List<HubSpotProperty> properties { get; set; }
+        public List<HubSpotProperty> Properties { get; set; }
 
         public HubSpotProperties()
         {
-            properties = new List<HubSpotProperty>();
+            Properties = new List<HubSpotProperty>();
         }
 
         public void AddIfNotExists(HubSpotProperty hubspotProperty)
         {
-            if (properties.Any(p => p.property == hubspotProperty.property))
+            if (Properties.Any(p => p.Property == hubspotProperty.Property))
             {
                 return;
             }
 
-            properties.Add(hubspotProperty);
+            Properties.Add(hubspotProperty);
         }
     }
 
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class HubSpotProperty
     {
         private readonly string _name;
@@ -56,13 +60,13 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
             _name = string.IsNullOrEmpty(name) ? string.Empty : name.ToLower();
             _prefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix.ToLower();
 
-            this.value = value;
+            this.Value = value;
         }
 
-        public string property =>
+        public string Property =>
             _name.Replace(_prefix, string.Empty)
                 .Replace("companyname", "company");
 
-        public string value { get; }
+        public string Value { get; }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotContactMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotContactMeshProcessor.cs
@@ -5,7 +5,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
     public class HubSpotContactMeshProcessor : HubSpotUpdateBaseMeshProcessor
     {
         public HubSpotContactMeshProcessor(ApplicationContext appContext)
-            : base(appContext, "contacts/v1/contact/vid/:vid/profile", CluedIn.Core.Data.EntityType.Infrastructure.Contact, CluedIn.Core.Data.EntityType.Person)
+            : base(appContext, "contacts/v1/contact/vid/:id/profile", "hubspot.contact.", CluedIn.Core.Data.EntityType.Infrastructure.Contact, CluedIn.Core.Data.EntityType.Person)
         {
         }
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotContactMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotContactMeshProcessor.cs
@@ -1,11 +1,12 @@
 ﻿using CluedIn.Core;
+using RestSharp;
 
 namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
 {
     public class HubSpotContactMeshProcessor : HubSpotUpdateBaseMeshProcessor
     {
         public HubSpotContactMeshProcessor(ApplicationContext appContext)
-            : base(appContext, "contacts/v1/contact/vid/:id/profile", "hubspot.contact.", CluedIn.Core.Data.EntityType.Infrastructure.Contact, CluedIn.Core.Data.EntityType.Person)
+            : base(appContext, "contacts/v1/contact/vid/:id/profile", "hubspot.contact.", Method.POST, CluedIn.Core.Data.EntityType.Infrastructure.Contact, CluedIn.Core.Data.EntityType.Person)
         {
         }
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotDealMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotDealMeshProcessor.cs
@@ -1,11 +1,12 @@
 ﻿using CluedIn.Core;
+using RestSharp;
 
 namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
 {
     public class HubSpotDealMeshProcessor : HubSpotUpdateBaseMeshProcessor
     {
         public HubSpotDealMeshProcessor(ApplicationContext appContext)
-            : base(appContext, "/deals/v1/deal/:id", "hubspot.deal.", CluedIn.Core.Data.EntityType.Sales.Deal)
+            : base(appContext, "/deals/v1/deal/:id", "hubspot.deal.", Method.PUT, CluedIn.Core.Data.EntityType.Sales.Deal)
         {
         }
     }

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotDealMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotDealMeshProcessor.cs
@@ -5,7 +5,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
     public class HubSpotDealMeshProcessor : HubSpotUpdateBaseMeshProcessor
     {
         public HubSpotDealMeshProcessor(ApplicationContext appContext)
-            : base(appContext, "deals/v1/deal/", CluedIn.Core.Data.EntityType.Sales.Deal)
+            : base(appContext, "/deals/v1/deal/:id", "hubspot.deal.", CluedIn.Core.Data.EntityType.Sales.Deal)
         {
         }
     }

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
@@ -17,13 +17,15 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
         public EntityType[] EntityType { get; }
         public string EditUrl { get; }
         public string VocabPrefix { get; }
+        public Method UpdateMethod { get; }
 
-        protected HubSpotUpdateBaseMeshProcessor(ApplicationContext appContext, string editUrl, string vocabPrefix, params EntityType[] entityType)
+        protected HubSpotUpdateBaseMeshProcessor(ApplicationContext appContext, string editUrl, string vocabPrefix, Method updateMethod, params EntityType[] entityType)
             : base(appContext)
         {
             EntityType = entityType;
             EditUrl = editUrl;
             VocabPrefix = vocabPrefix;
+            UpdateMethod = updateMethod;
         }
 
         public override bool Accept(MeshDataCommand command, MeshQuery query, IEntity entity)
@@ -76,7 +78,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
         {
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(EditUrl.Replace(":id", id), Method.POST);
+            var request = new RestRequest(EditUrl.Replace(":id", id), UpdateMethod);
             request.AddQueryParameter("hapikey", hubSpotCrawlJobData.ApiToken); // adds to POST or URL querystring based on Method
             request.AddJsonBody(properties.ToHubspotProperties(VocabPrefix));
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
@@ -106,7 +106,5 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
 
             return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
         }
-
-
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
@@ -16,12 +16,14 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
     {
         public EntityType[] EntityType { get; }
         public string EditUrl { get; }
+        public string VocabPrefix { get; }
 
-        protected HubSpotUpdateBaseMeshProcessor(ApplicationContext appContext, string editUrl, params EntityType[] entityType)
+        protected HubSpotUpdateBaseMeshProcessor(ApplicationContext appContext, string editUrl, string vocabPrefix, params EntityType[] entityType)
             : base(appContext)
         {
             EntityType = entityType;
             EditUrl = editUrl;
+            VocabPrefix = vocabPrefix;
         }
 
         public override bool Accept(MeshDataCommand command, MeshQuery query, IEntity entity)
@@ -74,9 +76,9 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
         {
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(EditUrl.Replace(":vid", id), Method.POST);
+            var request = new RestRequest(EditUrl.Replace(":id", id), Method.POST);
             request.AddQueryParameter("hapikey", hubSpotCrawlJobData.ApiToken); // adds to POST or URL querystring based on Method
-            request.AddJsonBody(properties.ToHubspotProperties());
+            request.AddJsonBody(properties.ToHubspotProperties(VocabPrefix));
 
             var result = client.ExecuteTaskAsync(request).Result;
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
@@ -7,6 +7,7 @@ using CluedIn.Core.Mesh;
 using CluedIn.Core.Messages.Processing;
 using CluedIn.Core.Messages.WebApp;
 using CluedIn.Crawling.HubSpot.Core;
+using CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions;
 using RestSharp;
 
 namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
@@ -73,9 +74,9 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
         {
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format(EditUrl + "{0}", id), Method.PUT);
+            var request = new RestRequest(EditUrl.Replace(":vid", id), Method.POST);
             request.AddQueryParameter("hapikey", hubSpotCrawlJobData.ApiToken); // adds to POST or URL querystring based on Method
-            request.AddJsonBody(properties);
+            request.AddJsonBody(properties.ToHubspotProperties());
 
             var result = client.ExecuteTaskAsync(request).Result;
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using CluedIn.Core;
 using CluedIn.Core.Data;
 using CluedIn.Core.Mesh;
@@ -76,11 +77,17 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
 
         public override List<QueryResponse> RunQueries(IDictionary<string, object> config, string id, Core.Mesh.Properties properties)
         {
+            var hubSpotProperties = properties.ToHubSpotProperties(VocabPrefix);
+            if(hubSpotProperties == null)
+            {
+                return new List<QueryResponse>() { new QueryResponse() { Content = "Properties are invalid.", StatusCode = HttpStatusCode.BadRequest } };
+            }
+
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var client = new RestClient("https://api.hubapi.com");
             var request = new RestRequest(EditUrl.Replace(":id", id), UpdateMethod);
             request.AddQueryParameter("hapikey", hubSpotCrawlJobData.ApiToken); // adds to POST or URL querystring based on Method
-            request.AddJsonBody(properties.ToHubspotProperties(VocabPrefix));
+            request.AddJsonBody(hubSpotProperties);
 
             var result = client.ExecuteTaskAsync(request).Result;
 

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
@@ -84,7 +84,7 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             // assert
             Assert.NotNull(result);
             Assert.Single(result.properties);
-            Assert.Equal("firstname", result.properties.First().Property);
+            Assert.Equal("firstname", result.properties.First().property);
         }
 
         [Fact]
@@ -107,8 +107,8 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             // assert
             Assert.NotNull(result);
             Assert.Equal(2, result.properties.Count());
-            Assert.Equal("firstname", result.properties.First().Property);
-            Assert.Equal("lastname", result.properties.Skip(1).First().Property);
+            Assert.Equal("firstname", result.properties.First().property);
+            Assert.Equal("lastname", result.properties.Skip(1).First().property);
         }
     }
 }

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using CluedIn.Core.Mesh;
 using CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions;
-using RestSharp.Extensions;
-using Shouldly;
+using Newtonsoft.Json;
+using RestSharp;
 using Xunit;
 
 namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
@@ -42,7 +40,7 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             var result = properties.ToHubSpotProperties("hubspot.contact.");
 
             // assert
-            Assert.Empty(result.properties);
+            Assert.Empty(result.Properties);
         }
 
         [Fact]
@@ -83,8 +81,8 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
 
             // assert
             Assert.NotNull(result);
-            Assert.Single(result.properties);
-            Assert.Equal("firstname", result.properties.First().property);
+            Assert.Single(result.Properties);
+            Assert.Equal("firstname", result.Properties.First().Property);
         }
 
         [Fact]
@@ -106,9 +104,32 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
 
             // assert
             Assert.NotNull(result);
-            Assert.Equal(2, result.properties.Count());
-            Assert.Equal("firstname", result.properties.First().property);
-            Assert.Equal("lastname", result.properties.Skip(1).First().property);
+            Assert.Equal(2, result.Properties.Count());
+            Assert.Equal("firstname", result.Properties.First().Property);
+            Assert.Equal("lastname", result.Properties.Skip(1).First().Property);
+        }
+
+        [Fact]
+        internal void ToHubspotProperties_ValidKeys_ShouldBeCamelCase()
+        {
+            // arrange
+            var properties = new Core.Mesh.Properties();
+            var internalProperties = new List<Property>
+            {
+                new Property { name = "acceptance.contact.firstName", value = "test" },
+                new Property { name = "salesforce.contact.firstName", value = "test" },
+                new Property { name = "hubspot.contact.firstName", value = "test" },
+                new Property { name = "hubspot.contact.lastNAME", value = "mctest" }
+            };
+            properties.properties = internalProperties;
+
+            // act
+            var result = properties.ToHubSpotProperties("hubspot.contact.");
+
+            var json = JsonConvert.SerializeObject(result);
+
+            // assert
+            Assert.Equal("{\"properties\":[{\"property\":\"firstname\",\"value\":\"test\"},{\"property\":\"lastname\",\"value\":\"mctest\"}]}", json);
         }
     }
 }

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CluedIn.Core.Mesh;
+using CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions;
+using RestSharp.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
+{
+    public class PropertiesExtensionsTests
+    {
+        [Fact]
+        internal void ToHubspotProperties_Null_ShouldBeEmpty()
+        {
+            // arrange
+            var properties = new Core.Mesh.Properties();
+
+            // act
+            var result = properties.ToHubspotProperties("hubspot.contact.");
+
+            // assert
+            Assert.Empty(result.properties);
+        }
+
+        [Fact]
+        internal void ToHubspotProperties_MissingKeys_ShouldBeEmpty()
+        {
+            // arrange
+            var properties = new Core.Mesh.Properties();
+            var internalProperties = new List<Property>
+            {
+                new Property { name = "acceptance.contact.firstName", value = "test" },
+                new Property { name = "salesforce.contact.firstName", value = "test" },
+                new Property { name = "d365.contact.firstName", value = "test" }
+            };
+            properties.properties = internalProperties;
+
+            // act
+            var result = properties.ToHubspotProperties("hubspot.contact.");
+
+            // assert
+            Assert.Empty(result.properties);
+        }
+
+        [Fact]
+        internal void ToHubspotProperties_InvalidPrefix_ShouldBeEmpty()
+        {
+            // arrange
+            var properties = new Core.Mesh.Properties();
+            var internalProperties = new List<Property>
+            {
+                new Property { name = "acceptance.contact.firstName", value = "test" },
+                new Property { name = "salesforce.contact.firstName", value = "test" },
+                new Property { name = "hubspot.contact.firstName", value = "test" }
+            };
+            properties.properties = internalProperties;
+
+            // act
+            var result = properties.ToHubspotProperties(string.Empty);
+
+            // assert
+            Assert.Empty(result.properties);
+        }
+
+        [Fact]
+        internal void ToHubspotProperties_ValidKeys_ShouldHaveOne()
+        {
+            // arrange
+            var properties = new Core.Mesh.Properties();
+            var internalProperties = new List<Property>
+            {
+                new Property { name = "acceptance.contact.firstName", value = "test" },
+                new Property { name = "salesforce.contact.firstName", value = "test" },
+                new Property { name = "hubspot.contact.firstName", value = "test" }
+            };
+            properties.properties = internalProperties;
+
+            // act
+            var result = properties.ToHubspotProperties("hubspot.contact.");
+
+            // assert
+            Assert.NotNull(result);
+            Assert.Single(result.properties);
+            Assert.Equal("firstname", result.properties.First().name);
+        }
+
+        [Fact]
+        internal void ToHubspotProperties_ValidKeys_ShouldHaveTwo()
+        {
+            // arrange
+            var properties = new Core.Mesh.Properties();
+            var internalProperties = new List<Property>
+            {
+                new Property { name = "acceptance.contact.firstName", value = "test" },
+                new Property { name = "salesforce.contact.firstName", value = "test" },
+                new Property { name = "hubspot.contact.firstName", value = "test" },
+                new Property { name = "hubspot.contact.lastNAME", value = "mctest" }
+            };
+            properties.properties = internalProperties;
+
+            // act
+            var result = properties.ToHubspotProperties("hubspot.contact.");
+
+            // assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.properties.Count());
+            Assert.Equal("firstname", result.properties.First().name);
+            Assert.Equal("lastname", result.properties.Skip(1).First().name);
+        }
+    }
+}

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
@@ -84,7 +84,7 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             // assert
             Assert.NotNull(result);
             Assert.Single(result.properties);
-            Assert.Equal("firstname", result.properties.First().name);
+            Assert.Equal("firstname", result.properties.First().property);
         }
 
         [Fact]
@@ -107,8 +107,8 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             // assert
             Assert.NotNull(result);
             Assert.Equal(2, result.properties.Count());
-            Assert.Equal("firstname", result.properties.First().name);
-            Assert.Equal("lastname", result.properties.Skip(1).First().name);
+            Assert.Equal("firstname", result.properties.First().property);
+            Assert.Equal("lastname", result.properties.Skip(1).First().property);
         }
     }
 }

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/Extensions/PropertiesExtensionsTests.cs
@@ -19,10 +19,10 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             var properties = new Core.Mesh.Properties();
 
             // act
-            var result = properties.ToHubspotProperties("hubspot.contact.");
+            var result = properties.ToHubSpotProperties("hubspot.contact.");
 
             // assert
-            Assert.Empty(result.properties);
+            Assert.Null(result);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             properties.properties = internalProperties;
 
             // act
-            var result = properties.ToHubspotProperties("hubspot.contact.");
+            var result = properties.ToHubSpotProperties("hubspot.contact.");
 
             // assert
             Assert.Empty(result.properties);
@@ -59,10 +59,10 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             properties.properties = internalProperties;
 
             // act
-            var result = properties.ToHubspotProperties(string.Empty);
+            var result = properties.ToHubSpotProperties(string.Empty);
 
             // assert
-            Assert.Empty(result.properties);
+            Assert.Null(result);
         }
 
         [Fact]
@@ -79,12 +79,12 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             properties.properties = internalProperties;
 
             // act
-            var result = properties.ToHubspotProperties("hubspot.contact.");
+            var result = properties.ToHubSpotProperties("hubspot.contact.");
 
             // assert
             Assert.NotNull(result);
             Assert.Single(result.properties);
-            Assert.Equal("firstname", result.properties.First().property);
+            Assert.Equal("firstname", result.properties.First().Property);
         }
 
         [Fact]
@@ -102,13 +102,13 @@ namespace CluedIn.Provider.HubSpot.Unit.Test.HubSpotProvider.Extensions
             properties.properties = internalProperties;
 
             // act
-            var result = properties.ToHubspotProperties("hubspot.contact.");
+            var result = properties.ToHubSpotProperties("hubspot.contact.");
 
             // assert
             Assert.NotNull(result);
             Assert.Equal(2, result.properties.Count());
-            Assert.Equal("firstname", result.properties.First().property);
-            Assert.Equal("lastname", result.properties.Skip(1).First().property);
+            Assert.Equal("firstname", result.properties.First().Property);
+            Assert.Equal("lastname", result.properties.Skip(1).First().Property);
         }
     }
 }


### PR DESCRIPTION
- Corrections for the contact entity type mesh:
- Use correct the hubspot api url
- All vocabkeys must be lower case
- The keypair must be property/value
- The cluedin prefix must be removed
- Non hubspot vocab keys must be removed