### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.0.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,15 +10,11 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
   </ItemGroup>
@@ -29,13 +25,10 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Castle.Windsor" Version="5.1.2" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="4.0.0" />
-    <PackageReference Update="RestSharp" Version="106.10.1" />
-
+    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="5.0.0-*" />
   </ItemGroup>
 
   <ItemGroup Label="Global tools">

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/HubSpot.Infrastructure/HubSpotClient.cs
+++ b/src/HubSpot.Infrastructure/HubSpotClient.cs
@@ -18,21 +18,17 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
     public class HubSpotClient : IHubSpotClient
     {
         private readonly ILogger<HubSpotClient> _log;
-        private readonly IRestClient _client;
+        private readonly RestClient _client;
 
-        public HubSpotClient(ILogger<HubSpotClient> log, HubSpotCrawlJobData hubspotCrawlJobData, IRestClient client)
+        public HubSpotClient(ILogger<HubSpotClient> log, HubSpotCrawlJobData hubspotCrawlJobData)
         {
             if (hubspotCrawlJobData == null)
                 throw new ArgumentNullException(nameof(hubspotCrawlJobData));
 
             _log = log ?? throw new ArgumentNullException(nameof(log));
 
-            _client = client ?? throw new ArgumentNullException(nameof(client));
-            _client.BaseUrl =
-                hubspotCrawlJobData.BaseUri != null
-                    ? hubspotCrawlJobData.BaseUri
-                    : new Uri(HubSpotConstants.ApiBaseUri);
-
+            var baseUri = hubspotCrawlJobData.BaseUri ?? new Uri(HubSpotConstants.ApiBaseUri);
+            _client = new RestClient(new RestClientOptions(baseUri));
             _client.AddDefaultHeader("Authorization", $"Bearer {hubspotCrawlJobData.ApiToken}");
             _client.AddDefaultHeader("Content-Type", "application/json");
         }
@@ -477,17 +473,17 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
 
         private async Task<T> GetAsync<T>(string url, IList<QueryStringParameter> parameters = null)
         {
-            var request = new RestRequest(url, Method.GET);
+            var request = new RestRequest(url, Method.Get);
 
             AddParametersToRequest<T>(parameters, request);
 
-            var response = await _client.ExecuteTaskAsync(request);
+            var response = await _client.ExecuteAsync(request);
 
             return GetRequestResponse<T>(url, response);
         }
         private async Task<T> PostAsync<T>(string url, object body, IList<QueryStringParameter> parameters = null)
         {
-            var request = new RestRequest(url, Method.POST);
+            var request = new RestRequest(url, Method.Post);
 
             AddParametersToRequest<T>(parameters, request);
 
@@ -496,7 +492,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
                 request.AddBody(body);
             }
 
-            var response = await _client.ExecuteTaskAsync(request);
+            var response = await _client.ExecuteAsync(request);
 
             return GetRequestResponse<T>(url, response);
         }
@@ -512,7 +508,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
             }
         }
 
-        private T GetRequestResponse<T>(string url, IRestResponse response)
+        private T GetRequestResponse<T>(string url, RestResponse response)
         {
             _log.LogTrace("HubSpotClient.GetAsync calling {url}", url);
             if ((int)response.StatusCode == 429)
@@ -527,7 +523,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                _log.LogError("Request to {url} failed, response {errorMessage} ({statusCode})", $"{_client.BaseUrl}{url}", response.ErrorMessage, response.StatusCode);
+                _log.LogError("Request to {url} failed, response {errorMessage} ({statusCode})", $"{_client.Options.BaseUrl}{url}", response.ErrorMessage, response.StatusCode);
 
                 throw new InvalidOperationException("Communication to HubSpot unavailable.");
             }
@@ -545,7 +541,7 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure
 
             public QueryStringParameter(string name, object value)
             {
-                Parameter = new Parameter(name, value.ToString(), ParameterType.QueryString);
+                Parameter = new QueryParameter(name, value.ToString());
             }
         }
 

--- a/src/HubSpot.Infrastructure/Installers/InstallComponents.cs
+++ b/src/HubSpot.Infrastructure/Installers/InstallComponents.cs
@@ -36,10 +36,6 @@ namespace CluedIn.Crawling.HubSpot.Infrastructure.Installers
                 container.Register(Component.For<ISystemNotifications, SystemNotifications>());
             }
 
-            if (!container.Kernel.HasComponent(typeof(IRestClient)) && !container.Kernel.HasComponent(typeof(RestClient)))
-            {
-                container.Register(Component.For<IRestClient, RestClient>().LifestyleTransient());
-            }
         }
     }
 }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Extensions/PropertiesExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Castle.Core.Internal;
 using CluedIn.Core.Mesh;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -13,7 +12,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Extensions
         public static HubSpotProperties ToHubSpotProperties(this Properties properties, string prefix)
         {
             var hubspotProperties = new HubSpotProperties();
-            if (properties?.properties == null || prefix.IsNullOrEmpty())
+            if (properties?.properties == null || string.IsNullOrEmpty(prefix))
             {
                 return null;
             }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Gdpr/HubSpotRemoveBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Gdpr/HubSpotRemoveBaseMeshProcessor.cs
@@ -83,12 +83,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Gdpr
         {
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format(DeleteUrl + "{0}", id), Method.DELETE);
-            
+            var request = new RestRequest(string.Format(DeleteUrl + "{0}", id), Method.Delete);
+
             client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
             client.AddDefaultHeader("Content-Type", "application/json");
 
-            var result = client.ExecuteTaskAsync(request).Result;
+            var result = client.ExecuteAsync(request).Result;
 
             return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
         }
@@ -98,12 +98,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Gdpr
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
 
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format(DeleteUrl + "{0}", id), Method.GET);
+            var request = new RestRequest(string.Format(DeleteUrl + "{0}", id), Method.Get);
 
             client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
             client.AddDefaultHeader("Content-Type", "application/json");
 
-            var result = client.ExecuteTaskAsync(request).Result;
+            var result = client.ExecuteAsync(request).Result;
 
             return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
         }

--- a/src/HubSpot.Provider/Mesh/HubSpot/Gdpr/HubSpotRemoveFromProcessingProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/Gdpr/HubSpotRemoveFromProcessingProcessor.cs
@@ -50,12 +50,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Gdpr
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
 
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format("/automation/v2/workflows/enrollments/contacts/{0}", GetLookupId(entity)), Method.GET);
+            var request = new RestRequest(string.Format("/automation/v2/workflows/enrollments/contacts/{0}", GetLookupId(entity)), Method.Get);
 
             client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
             client.AddDefaultHeader("Content-Type", "application/json");
 
-            var result = client.ExecuteTaskAsync<List<Workflow>>(request).Result;
+            var result = client.ExecuteAsync<List<Workflow>>(request).Result;
             if (result.Data == null)
             {
                 return new List<Core.Messages.WebApp.RawQuery>();
@@ -110,12 +110,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Gdpr
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var quereis = new List<QueryResponse>();
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format("/automation/v2/workflows/enrollments/contacts/{0}", id), Method.GET);
+            var request = new RestRequest(string.Format("/automation/v2/workflows/enrollments/contacts/{0}", id), Method.Get);
 
             client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
             client.AddDefaultHeader("Content-Type", "application/json");
 
-            var result = client.ExecuteTaskAsync<List<Workflow>>(request).Result;
+            var result = client.ExecuteAsync<List<Workflow>>(request).Result;
             if (result.Data == null)
             {
                 return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
@@ -133,12 +133,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Gdpr
 
             foreach (var workflow in result.Data)
             {
-                var removeRequest = new RestRequest(string.Format("/automation/v2/workflows/{0}/enrollments/contacts/{1}", workflow.id, entity.Properties[CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInPerson.Email]), Method.DELETE);
+                var removeRequest = new RestRequest(string.Format("/automation/v2/workflows/{0}/enrollments/contacts/{1}", workflow.id, entity.Properties[CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInPerson.Email]), Method.Delete);
 
                 client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
                 client.AddDefaultHeader("Content-Type", "application/json");
 
-                var removeResult = client.ExecuteTaskAsync(removeRequest).Result;
+                var removeResult = client.ExecuteAsync(removeRequest).Result;
 
                 quereis.Add(new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode });
             }
@@ -150,12 +150,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot.Gdpr
         {
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format("/automation/v2/workflows/enrollments/contacts/{0}", id), Method.GET);
+            var request = new RestRequest(string.Format("/automation/v2/workflows/enrollments/contacts/{0}", id), Method.Get);
 
             client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
             client.AddDefaultHeader("Content-Type", "application/json");
 
-            var result = client.ExecuteTaskAsync<List<Workflow>>(request).Result;
+            var result = client.ExecuteAsync<List<Workflow>>(request).Result;
 
             return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
         }

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotContactMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotContactMeshProcessor.cs
@@ -6,7 +6,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
     public class HubSpotContactMeshProcessor : HubSpotUpdateBaseMeshProcessor
     {
         public HubSpotContactMeshProcessor(ApplicationContext appContext)
-            : base(appContext, "contacts/v1/contact/vid/:id/profile", "hubspot.contact.", Method.POST, CluedIn.Core.Data.EntityType.Infrastructure.Contact, CluedIn.Core.Data.EntityType.Person)
+            : base(appContext, "contacts/v1/contact/vid/:id/profile", "hubspot.contact.", Method.Post, CluedIn.Core.Data.EntityType.Infrastructure.Contact, CluedIn.Core.Data.EntityType.Person)
         {
         }
 

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotDealMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotDealMeshProcessor.cs
@@ -6,7 +6,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
     public class HubSpotDealMeshProcessor : HubSpotUpdateBaseMeshProcessor
     {
         public HubSpotDealMeshProcessor(ApplicationContext appContext)
-            : base(appContext, "/deals/v1/deal/:id", "hubspot.deal.", Method.PUT, CluedIn.Core.Data.EntityType.Sales.Deal)
+            : base(appContext, "/deals/v1/deal/:id", "hubspot.deal.", Method.Put, CluedIn.Core.Data.EntityType.Sales.Deal)
         {
         }
     }

--- a/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
+++ b/src/HubSpot.Provider/Mesh/HubSpot/HubSpotUpdateBaseMeshProcessor.cs
@@ -93,7 +93,7 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
 
             request.AddJsonBody(JsonConvert.SerializeObject(hubSpotProperties));
 
-            var result = client.ExecuteTaskAsync(request).Result;
+            var result = client.ExecuteAsync(request).Result;
 
             return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
         }
@@ -103,12 +103,12 @@ namespace CluedIn.Provider.HubSpot.Mesh.HubSpot
             var hubSpotCrawlJobData = new HubSpotCrawlJobData(config);
 
             var client = new RestClient("https://api.hubapi.com");
-            var request = new RestRequest(string.Format(EditUrl + "{0}", id), Method.GET);
+            var request = new RestRequest(string.Format(EditUrl + "{0}", id), Method.Get);
 
             client.AddDefaultHeader("Authorization", $"Bearer {hubSpotCrawlJobData.ApiToken}");
             client.AddDefaultHeader("Content-Type", "application/json");
 
-            var result = client.ExecuteTaskAsync(request).Result;
+            var result = client.ExecuteAsync(request).Result;
 
             return new List<QueryResponse>() { new QueryResponse() { Content = result.Content, StatusCode = result.StatusCode } };
         }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2"/>
+    <PackageReference Include="AutoFixture.Xunit3"/>
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/test/integration/Crawling.HubSpot.Integration.Test/HubSpotClient/HappyPath.cs
+++ b/test/integration/Crawling.HubSpot.Integration.Test/HubSpotClient/HappyPath.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Crawling.HubSpot.Core;
 using CluedIn.Crawling.HubSpot.Core.Models;
 using Crawling.HubSpot.Test.Common;
 using Microsoft.Extensions.Logging;
-using RestSharp;
 using Xunit;
 using Moq;
 using Task = System.Threading.Tasks.Task;
@@ -23,8 +22,7 @@ namespace Crawling.HubSpot.Integration.Test.HubSpotClient
             var crawlJobData = new HubSpotCrawlJobData(HubSpotConfiguration.Create());
 
 
-            _sut = new CluedIn.Crawling.HubSpot.Infrastructure.HubSpotClient(logger.Object, crawlJobData,
-                new RestClient());
+            _sut = new CluedIn.Crawling.HubSpot.Infrastructure.HubSpotClient(logger.Object, crawlJobData);
         }
 
         [Fact]

--- a/test/integration/Crawling.HubSpot.Integration.Test/HubSpotDataIngestion.cs
+++ b/test/integration/Crawling.HubSpot.Integration.Test/HubSpotDataIngestion.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using CluedIn.Core.Data;
 using CrawlerIntegrationTesting.Clues;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Crawling.HubSpot.Integration.Test
 {

--- a/test/unit/Crawling.HubSpot.Unit.Test/ClueProducers/BaseClueProducerTest.cs
+++ b/test/unit/Crawling.HubSpot.Unit.Test/ClueProducers/BaseClueProducerTest.cs
@@ -1,5 +1,5 @@
 using System;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Core.Data;
 using CluedIn.Crawling;
 using CluedIn.Crawling.Factories;

--- a/test/unit/Crawling.HubSpot.Unit.Test/ClueProducers/ChannelClueProducerTests.cs
+++ b/test/unit/Crawling.HubSpot.Unit.Test/ClueProducers/ChannelClueProducerTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Core.Data;
 using CluedIn.Crawling;
 using CluedIn.Crawling.HubSpot.ClueProducers;

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotImageFetcher/HubSpotImageFetcherTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotImageFetcher/HubSpotImageFetcherTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
+using System.Threading;
 using CluedIn.Core;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Resources;
@@ -37,7 +39,8 @@ namespace Provider.HubSpot.Unit.Test.HubSpotImageFetcher
         {
             var fileData = ResourceHelper.GetFile(filename, Assembly.GetAssembly(typeof(HubSpotImageFetcherTests))).ToArray();
 
-            _restClient.Setup(n => n.DownloadData(new RestRequest(url))).Returns(fileData);
+            _restClient.Setup(n => n.DownloadStreamAsync(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new MemoryStream(fileData));
 
             var result = _sut.FetchAsRawDataPart(url, type, filename);
 
@@ -49,8 +52,9 @@ namespace Provider.HubSpot.Unit.Test.HubSpotImageFetcher
         public void CheckExceptionsAreLoggedFromFetchAsRawDataPart(string filename, string url, string type)
         {
             var request = new RestRequest(url);
-            _restClient.Setup(n => n.DownloadData(request)).Throws(new Exception("Invalid URL"));
-            
+            _restClient.Setup(n => n.DownloadStreamAsync(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Invalid URL"));
+
             _sut.FetchAsRawDataPart(request, type, filename);
 
             MoqUtils.VerifyLog(_log.Object, LogLevel.Warning, Times.Once());

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/GetCrawlJobDataBehaviour.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/GetCrawlJobDataBehaviour.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Core.Providers;
 using Shouldly;
 using Xunit;

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/GetHelperConfigurationBehaviour.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/GetHelperConfigurationBehaviour.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Linq;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Core.Crawling;
 using CluedIn.Crawling.HubSpot.Core;
 using Crawling.HubSpot.Test.Common;

--- a/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/HubSpotProviderTest.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubSpotProvider/HubSpotProviderTest.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using Castle.Windsor;
 using CluedIn.Core;
 using CluedIn.Core.Providers;
@@ -41,7 +41,7 @@ namespace Provider.HubSpot.Unit.Test.HubSpotProvider
             Logger = new Mock<ILogger<CluedIn.Provider.HubSpot.HubSpotProvider>>();
             Configuration = HubSpotConfiguration.Create();
             CrawlJobData = new HubSpotCrawlJobData(Configuration);
-            Client = new Mock<HubSpotClient>(new NullLogger<HubSpotClient>(), CrawlJobData, new RestClient());
+            Client = new Mock<HubSpotClient>(new NullLogger<HubSpotClient>(), CrawlJobData);
             Sut = new CluedIn.Provider.HubSpot.HubSpotProvider(ApplicationContext, NameClientFactory.Object, Logger.Object, null);
 
             NameClientFactory.Setup(n => n.CreateNew(It.IsAny<HubSpotCrawlJobData>())).Returns(() => Client.Object);

--- a/test/unit/Provider.HubSpot.Unit.Test/HubspotProvider/GetCrawlJobDataBehaviour.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubspotProvider/GetCrawlJobDataBehaviour.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Core.Providers;
 using Shouldly;
 using Xunit;

--- a/test/unit/Provider.HubSpot.Unit.Test/HubspotProvider/GetHelperConfigurationBehaviour.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubspotProvider/GetHelperConfigurationBehaviour.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Linq;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using CluedIn.Core.Crawling;
 using CluedIn.Crawling.HubSpot.Core;
 using Crawling.HubSpot.Test.Common;

--- a/test/unit/Provider.HubSpot.Unit.Test/HubspotProvider/HubSpotProviderTest.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/HubspotProvider/HubSpotProviderTest.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using AutoFixture.Xunit2;
+using AutoFixture.Xunit3;
 using Castle.Windsor;
 using CluedIn.Core;
 using CluedIn.Core.Providers;
@@ -41,7 +41,7 @@ namespace Provider.HubSpot.Unit.Test.HubSpotProvider
             Logger = new Mock<ILogger<CluedIn.Provider.HubSpot.HubSpotProvider>>();
             Configuration = HubSpotConfiguration.Create();
             CrawlJobData = new HubSpotCrawlJobData(Configuration);
-            Client = new Mock<HubSpotClient>(new NullLogger<HubSpotClient>(), CrawlJobData, new RestClient());
+            Client = new Mock<HubSpotClient>(new NullLogger<HubSpotClient>(), CrawlJobData);
             Sut = new CluedIn.Provider.HubSpot.HubSpotProvider(ApplicationContext, NameClientFactory.Object, Logger.Object, null);
 
             NameClientFactory.Setup(n => n.CreateNew(It.IsAny<HubSpotCrawlJobData>())).Returns(() => Client.Object);

--- a/test/unit/Provider.HubSpot.Unit.Test/Resources/ResourceHelperTests.cs
+++ b/test/unit/Provider.HubSpot.Unit.Test/Resources/ResourceHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using AutoFixture.Xunit2;
+﻿using AutoFixture.Xunit3;
 using CluedIn.Core.Resources;
 using CluedIn.Crawling.HubSpot.Core;
 using Xunit;


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- RestSharp updated to 114.0.0: `IRestResponse<T>` → `RestResponse<T>`; `Method.GET` → `Method.Get`; `ExecuteTaskAsync` → `ExecuteAsync`; `new Parameter(..., ParameterType.QueryString)` → `new QueryParameter(...)`; `client.BaseUrl` → configured via `RestClientOptions` at construction
- `HubSpotClient` constructor refactored: `IRestClient` removed from DI; `RestClient` created internally via `RestClientOptions`
- Windsor registration of `IRestClient` removed from `InstallComponents`
- xunit migrated from v2 to `xunit.v3 3.2.2`; `AutoFixture.Xunit2` → `AutoFixture.Xunit3 5.0.0-preview0012`